### PR TITLE
fix: S3 upload not working properly; local development S3 config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,6 @@
 import Config
 
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase
+config :ex_aws, http_client: ExAws.Request.Req
 
 import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,5 @@
+import Config
+
+config :ex_aws,
+  access_key_id: {:awscli, "default", 30000},
+  secret_access_key: {:awscli, "default", 30000}

--- a/lib/fetcher.ex
+++ b/lib/fetcher.ex
@@ -64,15 +64,16 @@ defmodule UncookedGps.Fetcher do
   def upload(vehicles) do
     s3_bucket = Application.get_env(:uncooked_gps, :s3_bucket)
     s3_path = Application.get_env(:uncooked_gps, :s3_path)
-    data = JSON.encode_to_iodata!(vehicles)
+    data = JSON.encode!(vehicles)
 
     if s3_bucket != nil do
+      request = S3.put_object(s3_bucket, s3_path, data)
+      ExAws.request(request)
       Logger.info("write path=s3://#{s3_bucket}/#{s3_path}")
-      S3.put_object(s3_bucket, s3_path, data)
     else
       path = "LightRailRawGPS.json"
-      Logger.info("write path=file://#{path}")
       File.write!(path, data)
+      Logger.info("write path=file://#{path}")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -22,6 +22,8 @@ defmodule UncookedGps.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      # used by ex_aws to parse AWS CLI settings/credentials
+      {:configparser_ex, "== 4.0.0", only: :dev},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
       {:req, "~> 0.5.10"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
+  "configparser_ex": {:hex, :configparser_ex, "4.0.0", "17e2b831cfa33a08c56effc610339b2986f0d82a9caa0ed18880a07658292ab6", [:mix], [], "hexpm", "02e6d1a559361a063cba7b75bc3eb2d6ad7e62730c551cc4703541fd11e65e5b"},
   "credo": {:hex, :credo, "1.7.12", "9e3c20463de4b5f3f23721527fcaf16722ec815e70ff6c60b86412c695d426c1", [:mix], [{:bunt, "~> 0.2.1 or ~> 1.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "8493d45c656c5427d9c729235b99d498bd133421f3e0a683e5c1b561471291e5"},
   "dialyxir": {:hex, :dialyxir, "1.4.5", "ca1571ac18e0f88d4ab245f0b60fa31ff1b12cbae2b11bd25d207f865e8ae78a", [:mix], [{:erlex, ">= 0.2.7", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b0fb08bb8107c750db5c0b324fa2df5ceaa0f9307690ee3c1f6ba5b9eb5d35c3"},
   "erlex": {:hex, :erlex, "0.2.7", "810e8725f96ab74d17aac676e748627a07bc87eb950d2b83acd29dc047a30595", [:mix], [], "hexpm", "3ed95f79d1a844c3f6bf0cea61e0d5612a42ce56da9c03f01df538685365efb0"},


### PR DESCRIPTION
UGPS is running in dev, but wasn't uploading properly because:

1. ExAws.S3 expects a `binary()`, not `iodata()`
2. ExAws expects the http client `hackney` (but can use `Req` if you ask it to)