### PR TITLE
fix: cast coordinates to float

### DIFF
--- a/lib/fetcher.ex
+++ b/lib/fetcher.ex
@@ -39,13 +39,16 @@ defmodule UncookedGps.Fetcher do
         [_, "", ""] ->
           {nil, nil}
 
-        [car, latitude, longitude, timestamp_local] ->
+        [car, latitude_str, longitude_str, timestamp_local] ->
           {:ok, timestamp_naive} =
             timestamp_local
             |> NaiveDateTime.from_iso8601()
 
           timestamp =
             timestamp_naive |> DateTime.from_naive!("America/New_York") |> DateTime.to_iso8601()
+
+          {latitude, _} = Float.parse(latitude_str)
+          {longitude, _} = Float.parse(longitude_str)
 
           {"UNKNOWN-#{car}",
            %{

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -28,16 +28,16 @@ defmodule UncookedGps.FetcherTest do
                  speed: nil,
                  bearing: nil,
                  car: "3606",
-                 latitude: "42.343370686319204",
-                 longitude: "-71.1168515041386",
+                 latitude: 42.343370686319204,
+                 longitude: -71.1168515041386,
                  updated_at: "2025-06-05T19:29:24-04:00"
                },
                "UNKNOWN-3608" => %{
                  speed: nil,
                  bearing: nil,
                  car: "3608",
-                 latitude: "42.393847580937326",
-                 longitude: "-71.1064506423318",
+                 latitude: 42.393847580937326,
+                 longitude: -71.1064506423318,
                  updated_at: "2025-06-05T16:24:41-04:00"
                }
              } == Fetcher.fetch()


### PR DESCRIPTION
Asana Task: [Restore "See on Map" button and functionality](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210057497375325)

Glides expects these to be floating point (rightfully).