### PR TITLE
fix: break out deploy-dev from deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,23 @@
+name: Deploy to Dev
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        type: environment
+        required: true
+        default: dev
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: dev
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy to Dev
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: dev
+    secrets: inherit

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -2,11 +2,6 @@ name: Deploy to Dev
 
 on:
   workflow_dispatch:
-    inputs:
-      environment:
-        type: environment
-        required: true
-        default: dev
   push:
     branches: ["main"]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,18 @@
 name: Deploy to ECS
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment:
-        type: environment
         required: true
-        default: dev
-  push:
-    branches: ["main"]
+        type: string
+    secrets:
+      AWS_ROLE_ARN:
+        required: true
+      DOCKER_REPO:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
 
 jobs:
   deploy:


### PR DESCRIPTION
Asana Task: [Restore "See on Map" button and functionality](https://app.asana.com/1/15492006741476/project/1200273269966439/task/1210057497375325)

The current deploy-prod is erroring right now because `deploy.yml` doesn't permit `workflow_call` (kickoff from other actions). So I'm:

- Changing `deploy.yml` to be call only, and is the former action for deploying to dev.
- Add `deploy-dev.yml` as the new way to deploy to dev, which calls `deploy.yml`.